### PR TITLE
Fixes tracker code bug on handling pushState

### DIFF
--- a/tracker/index.js
+++ b/tracker/index.js
@@ -58,15 +58,15 @@ import { removeTrailingSlash } from '../lib/url';
 
   /* Handle history */
 
-  const handlePush = (state, title, navaigatedUrl) => {
+  const handlePush = (state, title, navigatedURL) => {
     removeEvents();
     currentRef = currentUrl;
 
-    if (navaigatedUrl.startsWith('http')) {
-      const url = new URL(navaigatedUrl);
+    if (navigatedURL.toString().startsWith('http')) {
+      const url = new URL(navigatedURL.toString());
       currentUrl = `${url.pathname}${url.search}`;
     } else {
-      currentUrl = navaigatedUrl;
+      currentUrl = navigatedURL.toString();
     }
 
     pageView();


### PR DESCRIPTION
- Enforcing .toString() on navigatedURL, because without it it returns an object and break history state changes;
- Typo `navaigatedUrl` to `navigatedURL`;